### PR TITLE
zombies!

### DIFF
--- a/desub/desub.py
+++ b/desub/desub.py
@@ -120,8 +120,12 @@ class Desub:
         pp = self.pid
         if pp:
             try:
-                psutil.Process(pp)
-                return True
+                proc = psutil.Process(pp)
+                if str(proc.status) == 'running':
+                    return True
+                else:  # zombie script!
+                    self.stop()
+                    return False
             except psutil.NoSuchProcess:
                 pass
         return False


### PR DESCRIPTION
Hey there,

So, it turns out that scripts which terminate on their own (as opposed to being `proc.stop()`ed) tend to persist as zombies, causing false positives to arise in the `is_running()` call. This slight modification checks the status of existing processes, and stops those that don't have a status of `running`. Nonexistent processes produce a `False` as before.

Also, please update the desub pip project so that the requirements.txt installation grabs the right version.

Sorry I took like a million years to get webcontrol done; I'm sending an email to you now-ish about the new (read-only) version, which you can check out [here](https://github.com/chirpradio/chirpradio-webcontrol/tree/flask)
